### PR TITLE
Pass data to requests.post() as dict

### DIFF
--- a/sopel_modules/github/formatting.py
+++ b/sopel_modules/github/formatting.py
@@ -347,7 +347,7 @@ def fmt_status_message(payload=None):
 
 def shorten_url(url):
     try:
-        res = requests.post('https://git.io', 'url=' + url)
+        res = requests.post('https://git.io', {'url': url})
         return res.headers['location']
     except:
         return url


### PR DESCRIPTION
When passed as string, requests does not encode `data` at all, leading to URLs that contain `&` getting truncated at the first `&` character.

When passed as dict, requests encodes the `data` values so they get passed to the remote server correctly.

Fixes #10